### PR TITLE
Include project page and also prevent infinte loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Turn Jenkins Blue Ocean Descriptions into proper HTML
 
 ### Installation
 
-Install it from the chrome extension store here: https://chrome.google.com/webstore/detail/blue-ocean-description-ht/maahpenodjcdhodbonmdkfgnceddigae
+Install it from [the chrome extension store](https://chrome.google.com/webstore/detail/blue-ocean-description-ht/maahpenodjcdhodbonmdkfgnceddigae)
 
 
 ### Local Installation
@@ -25,7 +25,7 @@ git clone https://github.com/JRJurman/blue-ocean-description-htmlify-chrome-exte
 
 2. Open the extensions management page for your browser, most likely [chrome://extensions/](chrome://extensions/)
 
-3. Select `Load unpacked` at the top left, and select the package folder. It should now appear in your extensions with the appropriate icon and description
+3. Select `Load unpacked` at the top left, and select the package folder. It should now appear in your extensions with the appropriate icon and description. You may have to temporarily enable `Developer Mode` to do this. 
 
 ![](./installation-preview.png)
 

--- a/htmlify.js
+++ b/htmlify.js
@@ -7,9 +7,9 @@ observer = new MutationObserver((mutations) => {
 
     // Convert any description on the **project page** from text to html
     const messageColumn = document.querySelectorAll(".JTable-cell-contents .RunMessageCell");
-    // The title is set to raw HTML as well so clean that up
+    
     messageColumn.forEach(messageCell => {
-      // Reset the cell title
+      // The title is set to raw HTML as well so clean that up
       if (messageCell.title) {
         messageCell.title = "";
       }

--- a/htmlify.js
+++ b/htmlify.js
@@ -1,19 +1,40 @@
-// setup mutation observer, because this is the new cool way to see if elements are mounted
 let observer;
 observer = new MutationObserver((mutations) => {
   mutations.forEach((mutation) => {
-    const messageElement = document.querySelector(
-      ".RunDetails-Description .message"
-    );
+    // Convert any description on the **build page** from text to html
+    const buildPageDescription = document.querySelector(".RunDetails-Description .message");
+    convertTextToHtml(buildPageDescription);
 
-    // we need to know if there's a tag character, in the text... if there isn't, don't go crazy
-    const messageElementContainsTag = messageElement?.innerText?.includes("<");
-    if (messageElement && messageElementContainsTag) {
-      // this is the real magic - set the html of the message box to whatever the text of the message box is
-      messageElement.innerHTML = messageElement.innerText;
-    }
+    // Convert any description on the **project page** from text to html
+    const messageColumn = document.querySelectorAll(".JTable-cell-contents .RunMessageCell");
+    // The title is set to raw HTML as well so clean that up
+    messageColumn.forEach(messageCell => {
+      // Reset the cell title
+      if (messageCell.title) {
+        messageCell.title = "";
+      }
+      const messageCellInnerDescription = messageCell.querySelector(".RunMessageCellInner .unstyled-link");
+      convertTextToHtml(messageCellInnerDescription);
+    });
   });
 });
+
+/**
+ * Turns the raw HTML text rendered by an element to actual HTML if the raw text contains HTML elements
+ * @param {Element} element HTML element  
+ */
+function convertTextToHtml(element) {
+  // Presence of "<" might indicate that it might be raw HTML
+  if (element?.innerText?.includes("<")) {
+    // Test if the text is indeed HTML by using an HTML element like div
+    const tempDiv = document.createElement("div");
+    tempDiv.innerHTML = element.innerText;
+    // If the innerText is rendered differently, highly likely that it contains valid HTML elements
+    if (tempDiv.innerText != element.innerText) {
+      element.innerHTML = element.innerText;
+    }
+  }
+}
 
 // Define the configuration
 const config = {

--- a/htmlify.js
+++ b/htmlify.js
@@ -1,3 +1,21 @@
+/**
+ * Turns the raw HTML text rendered by an element to actual HTML if the raw text contains HTML elements
+ *
+ * @param {Element} element HTML element  
+ */
+function convertTextToHtml(element) {
+  // Presence of "<" might indicate that it might be raw HTML
+  if (element?.innerText?.includes("<")) {
+    // Test if the text is indeed HTML by using an HTML element like div
+    const tempDiv = document.createElement("div");
+    tempDiv.innerHTML = element.innerText;
+    // If the innerText is rendered differently, highly likely that it contains valid HTML elements
+    if (tempDiv.innerText != element.innerText) {
+      element.innerHTML = element.innerText;
+    }
+  }
+}
+
 let observer;
 observer = new MutationObserver((mutations) => {
   mutations.forEach((mutation) => {
@@ -18,23 +36,6 @@ observer = new MutationObserver((mutations) => {
     });
   });
 });
-
-/**
- * Turns the raw HTML text rendered by an element to actual HTML if the raw text contains HTML elements
- * @param {Element} element HTML element  
- */
-function convertTextToHtml(element) {
-  // Presence of "<" might indicate that it might be raw HTML
-  if (element?.innerText?.includes("<")) {
-    // Test if the text is indeed HTML by using an HTML element like div
-    const tempDiv = document.createElement("div");
-    tempDiv.innerHTML = element.innerText;
-    // If the innerText is rendered differently, highly likely that it contains valid HTML elements
-    if (tempDiv.innerText != element.innerText) {
-      element.innerHTML = element.innerText;
-    }
-  }
-}
 
 // Define the configuration
 const config = {


### PR DESCRIPTION
The description field is also shown in the message column on the project
page. This change will turn that text into HTML as well. A new function
convertTextToHtml is created to handle the conversion logic.

This change also tries to solve the infinite loop problem when the
description contains valid less than (<) symbol by checking if the
inner text is rendered differently. This should work!

Resolves #1 & #2 